### PR TITLE
Add kestrel logging

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/Logger.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logger.scala
@@ -16,8 +16,7 @@
 
 package com.typesafe.scalalogging
 
-import org.slf4j.{ Logger => Underlying }
-import org.slf4j.Marker
+import org.slf4j.{ Marker, Logger => Underlying }
 
 /**
  * Companion for [[Logger]], providing a factory for [[Logger]]s.
@@ -50,6 +49,8 @@ final class Logger private (val underlying: Underlying) {
 
   def error(marker: Marker, message: String, args: AnyRef*): Unit = macro LoggerMacro.errorMessageArgsMarker
 
+  def error[T](block: => T): T = macro LoggerMacro.errorMessageBlock
+
   // Warn
 
   def warn(message: String): Unit = macro LoggerMacro.warnMessage
@@ -63,6 +64,8 @@ final class Logger private (val underlying: Underlying) {
   def warn(marker: Marker, message: String, cause: Throwable): Unit = macro LoggerMacro.warnMessageCauseMarker
 
   def warn(marker: Marker, message: String, args: AnyRef*): Unit = macro LoggerMacro.warnMessageArgsMarker
+
+  def warn[T](block: => T): T = macro LoggerMacro.warnMessageBlock
 
   // Info
 
@@ -78,6 +81,8 @@ final class Logger private (val underlying: Underlying) {
 
   def info(marker: Marker, message: String, args: AnyRef*): Unit = macro LoggerMacro.infoMessageArgsMarker
 
+  def info[T](block: => T): T = macro LoggerMacro.infoMessageBlock
+
   // Debug
 
   def debug(message: String): Unit = macro LoggerMacro.debugMessage
@@ -91,6 +96,8 @@ final class Logger private (val underlying: Underlying) {
   def debug(marker: Marker, message: String, cause: Throwable): Unit = macro LoggerMacro.debugMessageCauseMarker
 
   def debug(marker: Marker, message: String, args: AnyRef*): Unit = macro LoggerMacro.debugMessageArgsMarker
+
+  def debug[T](block: => T): T = macro LoggerMacro.debugMessageBlock
 
   // Trace
 
@@ -106,4 +113,5 @@ final class Logger private (val underlying: Underlying) {
 
   def trace(marker: Marker, message: String, args: AnyRef*): Unit = macro LoggerMacro.traceMessageArgsMarker
 
+  def trace[T](block: => T): T = macro LoggerMacro.traceMessageBlock
 }

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -17,6 +17,7 @@
 package com.typesafe.scalalogging
 
 import org.slf4j.Marker
+
 import scala.reflect.macros.blackbox.Context
 
 private object LoggerMacro {
@@ -67,6 +68,17 @@ private object LoggerMacro {
       q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, ..$args)"
   }
 
+  def errorMessageBlock(c: LoggerContext)(block: c.Tree) = {
+    import c.universe._
+    val q"..$stats" = block
+    val underlying = q"${c.prefix}.underlying"
+    val loggedStats = stats.flatMap { stat =>
+      val msg = "executing " + showCode(stat)
+      List(q"if ($underlying.isErrorEnabled) $underlying.error($msg)", stat)
+    }
+    q"..$loggedStats"
+  }
+
   // Warn
 
   def warnMessage(c: LoggerContext)(message: c.Expr[String]) = {
@@ -109,6 +121,17 @@ private object LoggerMacro {
       q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, List(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, ..$args)"
+  }
+
+  def warnMessageBlock(c: LoggerContext)(block: c.Tree) = {
+    import c.universe._
+    val q"..$stats" = block
+    val underlying = q"${c.prefix}.underlying"
+    val loggedStats = stats.flatMap { stat =>
+      val msg = "executing " + showCode(stat)
+      List(q"if ($underlying.isWarnEnabled) $underlying.warn($msg)", stat)
+    }
+    q"..$loggedStats"
   }
 
   // Info
@@ -155,6 +178,17 @@ private object LoggerMacro {
       q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, ..$args)"
   }
 
+  def infoMessageBlock(c: LoggerContext)(block: c.Tree) = {
+    import c.universe._
+    val q"..$stats" = block
+    val underlying = q"${c.prefix}.underlying"
+    val loggedStats = stats.flatMap { stat =>
+      val msg = "executing " + showCode(stat)
+      List(q"if ($underlying.isInfoEnabled) $underlying.info($msg)", stat)
+    }
+    q"..$loggedStats"
+  }
+
   // Debug
 
   def debugMessage(c: LoggerContext)(message: c.Expr[String]) = {
@@ -197,6 +231,17 @@ private object LoggerMacro {
       q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, List(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, ..$args)"
+  }
+
+  def debugMessageBlock(c: LoggerContext)(block: c.Tree) = {
+    import c.universe._
+    val q"..$stats" = block
+    val underlying = q"${c.prefix}.underlying"
+    val loggedStats = stats.flatMap { stat =>
+      val msg = "executing " + showCode(stat)
+      List(q"if ($underlying.isDebugEnabled) $underlying.debug($msg)", stat)
+    }
+    q"..$loggedStats"
   }
 
   // Trace
@@ -243,4 +288,14 @@ private object LoggerMacro {
       q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, ..$args)"
   }
 
+  def traceMessageBlock(c: LoggerContext)(block: c.Tree) = {
+    import c.universe._
+    val q"..$stats" = block
+    val underlying = q"${c.prefix}.underlying"
+    val loggedStats = stats.flatMap { stat =>
+      val msg = "executing " + showCode(stat)
+      List(q"if ($underlying.isTraceEnabled) $underlying.trace($msg)", stat)
+    }
+    q"..$loggedStats"
+  }
 }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -18,9 +18,9 @@ package com.typesafe.scalalogging
 
 import org.mockito.Matchers._
 import org.mockito.Mockito._
-import org.slf4j.{ Logger => Underlying }
-import org.scalatest.{ Matchers, WordSpec }
 import org.scalatest.mock.MockitoSugar
+import org.scalatest.{ Matchers, WordSpec }
+import org.slf4j.{ Logger => Underlying }
 
 class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
 
@@ -85,6 +85,29 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
     }
   }
 
+  "Calling error with a block" should {
+
+    "call the underlying logger's error message if the error level is enabled" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      val result: String = logger.error {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying).error(s"executing f.arg1")
+    }
+
+    "not call the underlying logger's error method if the error level is not enabled" in {
+      val f = fixture(_.isErrorEnabled, false)
+      import f._
+      val result: String = logger.error {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying, never).error(msg, List(arg1): _*)
+    }
+  }
+
   // Warn
 
   "Calling warn with a message" should {
@@ -143,6 +166,29 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).warn(msg, List(arg1, arg2): _*)
       logger.warn(msg, arg1, arg2, arg3)
       verify(underlying, never).warn(msg, arg1, arg2, arg3)
+    }
+  }
+
+  "Calling warn with a block" should {
+
+    "call the underlying logger's warn message if the warn level is enabled" in {
+      val f = fixture(_.isWarnEnabled, true)
+      import f._
+      val result: String = logger.warn {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying).warn(s"executing f.arg1")
+    }
+
+    "not call the underlying logger's warn method if the warn level is not enabled" in {
+      val f = fixture(_.isWarnEnabled, false)
+      import f._
+      val result: String = logger.warn {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying, never).warn(msg, List(arg1): _*)
     }
   }
 
@@ -207,6 +253,29 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
     }
   }
 
+  "Calling info with a block" should {
+
+    "call the underlying logger's warn message if the warn level is enabled" in {
+      val f = fixture(_.isInfoEnabled, true)
+      import f._
+      val result: String = logger.info {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying).info(s"executing f.arg1")
+    }
+
+    "not call the underlying logger's warn method if the warn level is not enabled" in {
+      val f = fixture(_.isInfoEnabled, false)
+      import f._
+      val result: String = logger.info {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying, never).info(msg, List(arg1): _*)
+    }
+  }
+
   // Debug
 
   "Calling debug with a message" should {
@@ -268,6 +337,29 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
     }
   }
 
+  "Calling debug with a block" should {
+
+    "call the underlying logger's warn message if the warn level is enabled" in {
+      val f = fixture(_.isDebugEnabled, true)
+      import f._
+      val result: String = logger.debug {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying).debug(s"executing f.arg1")
+    }
+
+    "not call the underlying logger's warn method if the warn level is not enabled" in {
+      val f = fixture(_.isDebugEnabled, false)
+      import f._
+      val result: String = logger.debug {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying, never).debug(msg, List(arg1): _*)
+    }
+  }
+
   // Trace
 
   "Calling trace with a message" should {
@@ -326,6 +418,29 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).trace(msg, List(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying, never).trace(msg, arg1, arg2, arg3)
+    }
+  }
+
+  "Calling trace with a block" should {
+
+    "call the underlying logger's trace message if the trace level is enabled" in {
+      val f = fixture(_.isTraceEnabled, true)
+      import f._
+      val result: String = logger.trace {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying).trace(s"executing f.arg1")
+    }
+
+    "not call the underlying logger's trace method if the trace level is not enabled" in {
+      val f = fixture(_.isTraceEnabled, false)
+      import f._
+      val result: String = logger.trace {
+        arg1
+      }
+      result shouldEqual (arg1)
+      verify(underlying, never).trace(msg, List(arg1): _*)
     }
   }
 


### PR DESCRIPTION
Add logging with a block, i.e.

```
def addOne(input:Int): Int = logger.debug {
  input + 1
}
```
