### PR TITLE
LazyLogging and StrictLogging now have @transient logger

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/Logging.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logging.scala
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
  */
 trait LazyLogging {
 
+  @transient
   protected lazy val logger: Logger =
     Logger(LoggerFactory.getLogger(getClass.getName))
 }
@@ -34,6 +35,7 @@ trait LazyLogging {
  */
 trait StrictLogging {
 
+  @transient
   protected val logger: Logger =
     Logger(LoggerFactory.getLogger(getClass.getName))
 }


### PR DESCRIPTION
I verified that this works for `StrictLogging` using the Kryo serializer; but it does not work using the Java serializer.  See my comments on https://github.com/typesafehub/scala-logging/issues/26

Because the test uses Kryo, I did not add it to the commit. 