### PR TITLE
Upgrade to sbt-pgp 1.0.0

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.SbtPgp._
+import com.typesafe.sbt.pgp._
 import com.typesafe.sbt.SbtScalariform._
 import sbt._
 import sbt.Keys._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 


### PR DESCRIPTION
You will run into https://github.com/sbt/sbt-pgp/issues/67 if you have ~/.sbt/0.13/plugins/gpg.sbt loaded with 1.0.0 and a project configured with 0.8.3.  The simplest solution here is to upgrade to 1.0.0.