### PR TITLE
Made Logger serializable

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/Logger.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logger.scala
@@ -34,7 +34,8 @@ object Logger {
 /**
  * Implementation for a performant logger based on macros and an underlying `org.slf4j.Logger`.
  */
-final class Logger private (val underlying: Underlying) {
+@SerialVersionUID(538248225L)
+final class Logger private (val underlying: Underlying) extends Serializable {
 
   // Error
 


### PR DESCRIPTION
Currently the logger could not be serializable which forces extending classes to override the logger to declare it as transient, which leads to null loggers on deserialization.  Since the slf4j logger is serializable we can make our logger serializable as well.

ref #26 #44 