### PR TITLE
String Interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ if (logger.isDebugEnabled) logger.debug(s"Some $expensive message!")
 A compatible logging backend is [Logback](http://logback.qos.ch), add it to your sbt build definition:
 
 ```scala
-libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.1.7"
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 ```
 
 If you are looking for a version compatible with Scala 2.10, check out Scala Logging 2.x.
@@ -93,6 +93,28 @@ class MyClass extends LazyLogging {
 ##### 3.2.0
  - SLF4J loggers and our Logger now survive serialization. By survive serialization, we mean that the
    deserialized logger instances are fully functional.
+
+## String Interpolation
+It is idiomatic to use Scala's string interpolation `logger.error(s"log $value")` instead of SLF4J string interpolation `logger.error("log {}", value)`.
+However there are some tools (such as [Sentry](https://sentry.io)) that use the log message format as grouping key. Therefore they do not work well with
+Scala's string interpolation.
+
+Scala Logging replaces simple string interpolations with their SLF4J counterparts like this:
+
+```scala
+logger.error(s"my log message: $arg1 $arg2 $arg3")
+```
+
+```scala
+logger.error("my log message: {} {} {}", arg1, arg2, arg3)
+```
+
+This has no effect on behavior and performace should be comparable (depends on the underlying logging library).
+
+### Limitations
+ - Works only when string interpolation is directly used inside the logging statement. That is when the log message is static (available at compile time).
+ - Works only for the `logger.<level>(message)` and `logger.<level>(marker, message)` logging methods. It does not work if you want to log an exception and
+ use string interpolation too (this is a limitation of the SLF4J API).
 
 ## Line numbers in log message?
 

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -43,6 +43,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(msg)
       verify(underlying, never).error(anyString)
     }
+
+    "call the underlying logger's error method with arguments if the error level is enabled and string is interpolated" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"msg $arg1 $arg2 $arg3")
+      verify(underlying).error("msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling error with a message and cause" should {
@@ -103,6 +110,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.warn(msg)
       verify(underlying, never).warn(anyString)
+    }
+
+    "call the underlying logger's warn method if the warn level is enabled and string is interpolated" in {
+      val f = fixture(_.isWarnEnabled, true)
+      import f._
+      logger.warn(s"msg $arg1 $arg2 $arg3")
+      verify(underlying).warn("msg {} {} {}", arg1, arg2, arg3)
     }
   }
 
@@ -165,6 +179,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.info(msg)
       verify(underlying, never).info(anyString)
     }
+
+    "call the underlying logger's info method if the info level is enabled and string is interpolated" in {
+      val f = fixture(_.isInfoEnabled, true)
+      import f._
+      logger.info(s"msg $arg1 $arg2 $arg3")
+      verify(underlying).info("msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling info with a message and cause" should {
@@ -226,6 +247,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.debug(msg)
       verify(underlying, never).debug(anyString)
     }
+
+    "call the underlying logger's debug method if the debug level is enabled and string is interpolated" in {
+      val f = fixture(_.isDebugEnabled, true)
+      import f._
+      logger.debug(s"msg $arg1 $arg2 $arg3")
+      verify(underlying).debug("msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling debug with a message and cause" should {
@@ -286,6 +314,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.trace(msg)
       verify(underlying, never).trace(anyString)
+    }
+
+    "call the underlying logger's trace method if the trace level is enabled and string is interpolated" in {
+      val f = fixture(_.isTraceEnabled, true)
+      import f._
+      logger.trace(s"msg $arg1 $arg2 $arg3")
+      verify(underlying).trace("msg {} {} {}", arg1, arg2, arg3)
     }
   }
 

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -50,6 +50,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(s"msg $arg1 $arg2 $arg3")
       verify(underlying).error("msg {} {} {}", arg1, arg2, arg3)
     }
+
+    "call the underlying logger's error method with two arguments if the error level is enabled and string is interpolated" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"msg $arg1 $arg2")
+      verify(underlying).error("msg {} {}", List(arg1, arg2): _*)
+    }
   }
 
   "Calling error with a message and cause" should {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -58,6 +58,13 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(marker, msg)
       verify(underlying, never).error(refEq(DummyMarker), anyString)
     }
+
+    "call the underlying logger's error method if the error level is enabled and string is interpolated" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(marker, s"msg $arg1 $arg2 $arg3")
+      verify(underlying).error(marker, "msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling error with a marker and a message and cause" should {
@@ -118,6 +125,13 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.warn(marker, msg)
       verify(underlying, never).warn(refEq(DummyMarker), anyString)
+    }
+
+    "call the underlying logger's warn method if the warn level is enabled and string is interpolated" in {
+      val f = fixture(_.isWarnEnabled, true)
+      import f._
+      logger.warn(marker, s"msg $arg1 $arg2 $arg3")
+      verify(underlying).warn(marker, "msg {} {} {}", arg1, arg2, arg3)
     }
   }
 
@@ -180,6 +194,13 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.info(marker, msg)
       verify(underlying, never).info(refEq(DummyMarker), anyString)
     }
+
+    "call the underlying logger's info method if the info level is enabled and string is interpolated" in {
+      val f = fixture(_.isInfoEnabled, true)
+      import f._
+      logger.info(marker, s"msg $arg1 $arg2 $arg3")
+      verify(underlying).info(marker, "msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling info with a marker and a message and cause" should {
@@ -241,6 +262,13 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.debug(marker, msg)
       verify(underlying, never).debug(refEq(DummyMarker), anyString)
     }
+
+    "call the underlying logger's debug method if the debug level is enabled and string is interpolated" in {
+      val f = fixture(_.isDebugEnabled, true)
+      import f._
+      logger.debug(marker, s"msg $arg1 $arg2 $arg3")
+      verify(underlying).debug(marker, "msg {} {} {}", arg1, arg2, arg3)
+    }
   }
 
   "Calling debug with a marker and a message and cause" should {
@@ -301,6 +329,13 @@ class LoggerWithMarkerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.trace(marker, msg)
       verify(underlying, never).trace(refEq(DummyMarker), anyString)
+    }
+
+    "call the underlying logger's trace method if the trace level is enabled and string is interpolated" in {
+      val f = fixture(_.isTraceEnabled, true)
+      import f._
+      logger.trace(marker, s"msg $arg1 $arg2 $arg3")
+      verify(underlying).trace(marker, "msg {} {} {}", arg1, arg2, arg3)
     }
   }
 


### PR DESCRIPTION
New feature that allows the users to use Scala's string interpolation that is automatically translated to SFL4J string interpolation so that tools like Sentry work correctly.

Unfortunately this approach has its limitations which are described in README.