### PR TITLE
Fix compile errors for interpolated AnyVals

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -243,7 +243,10 @@ private object LoggerMacro {
       case q"scala.StringContext.apply(..$parts).s(..$args)" =>
         val strings = parts.collect { case Literal(Constant(s: String)) => s }
         val messageFormat = strings.mkString(ArgumentMarker)
-        (c.Expr(q"$messageFormat"), args.map(arg => q"$arg").map(c.Expr[Any](_)))
+        (c.Expr(q"$messageFormat"), args map { arg =>
+          // Box interpolated AnyVals by explicitly getting the string representation
+          c.Expr[Any](if (arg.tpe <:< weakTypeOf[AnyVal]) q"$arg.toString" else arg)
+        })
 
       case _ => (message, Seq.empty)
     }

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -239,8 +239,8 @@ private object LoggerMacro {
 
     message.tree match {
       case q"scala.StringContext.apply(..$parts).s(..$args)" =>
-        // Escape slf4j format anchors
-        val messageFormat = parts.map({ case Literal(Constant(s: String)) => s.replace("{}", "\\{}") }).mkString("{}")
+        // Emulate standard interpolator escaping and escape literal slf4j format anchors
+        val messageFormat = parts.map({ case Literal(Constant(s: String)) => StringContext.treatEscapes(s).replace("{}", "\\{}") }).mkString("{}")
         (c.Expr(q"$messageFormat"), args map { arg =>
           // Box interpolated AnyVals by explicitly getting the string representation
           c.Expr[Any](if (arg.tpe <:< weakTypeOf[AnyVal]) q"$arg.toString" else arg)

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -21,8 +21,6 @@ import scala.reflect.macros.blackbox.Context
 
 private object LoggerMacro {
 
-  private final val ArgumentMarker = "{}"
-
   type LoggerContext = Context { type PrefixType = Logger }
 
   // Error
@@ -241,8 +239,8 @@ private object LoggerMacro {
 
     message.tree match {
       case q"scala.StringContext.apply(..$parts).s(..$args)" =>
-        val strings = parts.collect { case Literal(Constant(s: String)) => s }
-        val messageFormat = strings.mkString(ArgumentMarker)
+        // Escape slf4j format anchors
+        val messageFormat = parts.map({ case Literal(Constant(s: String)) => s.replace("{}", "\\{}") }).mkString("{}")
         (c.Expr(q"$messageFormat"), args map { arg =>
           // Box interpolated AnyVals by explicitly getting the string representation
           c.Expr[Any](if (arg.tpe <:< weakTypeOf[AnyVal]) q"$arg.toString" else arg)

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -40,7 +40,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isErrorEnabled) $underlying.error($message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isErrorEnabled) $underlying.error($message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isErrorEnabled) $underlying.error($message, ..$args)"
   }
@@ -60,7 +60,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isErrorEnabled) $underlying.error($marker, $message, ..$args)"
   }
@@ -82,7 +82,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isWarnEnabled) $underlying.warn($message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isWarnEnabled) $underlying.warn($message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isWarnEnabled) $underlying.warn($message, ..$args)"
   }
@@ -102,7 +102,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isWarnEnabled) $underlying.warn($marker, $message, ..$args)"
   }
@@ -124,7 +124,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isInfoEnabled) $underlying.info($message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isInfoEnabled) $underlying.info($message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isInfoEnabled) $underlying.info($message, ..$args)"
   }
@@ -144,7 +144,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isInfoEnabled) $underlying.info($marker, $message, ..$args)"
   }
@@ -166,7 +166,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isDebugEnabled) $underlying.debug($message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isDebugEnabled) $underlying.debug($message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isDebugEnabled) $underlying.debug($message, ..$args)"
   }
@@ -186,7 +186,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isDebugEnabled) $underlying.debug($marker, $message, ..$args)"
   }
@@ -208,7 +208,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isTraceEnabled) $underlying.trace($message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isTraceEnabled) $underlying.trace($message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isTraceEnabled) $underlying.trace($message, ..$args)"
   }
@@ -228,7 +228,7 @@ private object LoggerMacro {
     import c.universe._
     val underlying = q"${c.prefix}.underlying"
     if (args.length == 2)
-      q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, _root_.scala.List(${args(0)}, ${args(1)}): _*)"
+      q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, _root_.scala.Array(${args(0)}, ${args(1)}): _*)"
     else
       q"if ($underlying.isTraceEnabled) $underlying.trace($marker, $message, ..$args)"
   }

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -68,13 +68,18 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying).error("msg {}", 1.toString)
     }
 
-    "call the underlying logger's error method preserving literal format anchors when the message is interpolated" in {
+    "call the underlying logger's error method escaping literal format anchors" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._
       logger.error(s"foo {} bar $arg1")
       verify(underlying).error("foo \\{} bar {}", arg1)
     }
-
+    "call the underlying logger's error method without escaping format anchors when the message has no interpolations" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo {} bar")
+      verify(underlying).error("foo {} bar")
+    }
     "call the underlying logger's error method when the interpolated string contains escape sequences" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -64,6 +64,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(s"msg ${1}")
       verify(underlying).error("msg {}", 1.toString)
     }
+
+    "call the underlying logger's error method preserving literal format anchors when the message is interpolated" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo {} bar $arg1")
+      verify(underlying).error("foo \\{} bar {}", arg1)
+    }
   }
 
   "Calling error with a message and cause" should {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -420,11 +420,18 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
 
   "Logging a message using the standard string interpolator" should {
 
-    "call the underlying format method with the string representation of AnyVal arguments" in {
+    "call the underlying format method with boxed versions of value arguments" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._
       logger.error(s"msg ${1}")
-      verify(underlying).error("msg {}", 1.toString)
+      verify(underlying).error("msg {}", 1.asInstanceOf[AnyRef])
+    }
+
+    "call the underlying format method with boxed versions of arguments of type Any" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"msg ${1.asInstanceOf[Any]}")
+      verify(underlying).error("msg {}", 1.asInstanceOf[AnyRef])
     }
 
     "call the underlying format method escaping literal format anchors" in {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -43,22 +43,25 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(msg)
       verify(underlying, never).error(anyString)
     }
+  }
 
-    "call the underlying logger's error method with arguments if the error level is enabled and string is interpolated" in {
+  "Calling error with an interpolated message" should {
+
+    "call the underlying logger's error method with arguments if the error level is enabled" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._
       logger.error(s"msg $arg1 $arg2 $arg3")
       verify(underlying).error("msg {} {} {}", arg1, arg2, arg3)
     }
 
-    "call the underlying logger's error method with two arguments if the error level is enabled and string is interpolated" in {
+    "call the underlying logger's error method with two arguments if the error level is enabled" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._
       logger.error(s"msg $arg1 $arg2")
       verify(underlying).error("msg {} {}", List(arg1, arg2): _*)
     }
 
-    "call the underlying logger's error method with the string representation of interpolated AnyVal arguments" in {
+    "call the underlying logger's error method with the string representation AnyVal arguments" in {
       val f = fixture(_.isErrorEnabled, true)
       import f._
       logger.error(s"msg ${1}")
@@ -132,8 +135,10 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.warn(msg)
       verify(underlying, never).warn(anyString)
     }
+  }
+  "Calling warn with an interpolated message" should {
 
-    "call the underlying logger's warn method if the warn level is enabled and string is interpolated" in {
+    "call the underlying logger's warn method if the warn level is enabled" in {
       val f = fixture(_.isWarnEnabled, true)
       import f._
       logger.warn(s"msg $arg1 $arg2 $arg3")
@@ -200,8 +205,10 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.info(msg)
       verify(underlying, never).info(anyString)
     }
+  }
+  "Calling info with an interpolated message" should {
 
-    "call the underlying logger's info method if the info level is enabled and string is interpolated" in {
+    "call the underlying logger's info method if the info level is enabled" in {
       val f = fixture(_.isInfoEnabled, true)
       import f._
       logger.info(s"msg $arg1 $arg2 $arg3")
@@ -268,15 +275,17 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.debug(msg)
       verify(underlying, never).debug(anyString)
     }
+  }
+  "Calling debug with an interpolated message" should {
 
-    "call the underlying logger's debug method if the debug level is enabled and string is interpolated" in {
+    "call the underlying logger's debug method if the debug level is enabled" in {
       val f = fixture(_.isDebugEnabled, true)
       import f._
       logger.debug(s"msg $arg1 $arg2 $arg3")
       verify(underlying).debug("msg {} {} {}", arg1, arg2, arg3)
     }
 
-    "call the underlying logger's debug method with the string representation of interpolated AnyVal arguments" in {
+    "call the underlying logger's debug method with the string representation of AnyVal arguments" in {
       val f = fixture(_.isDebugEnabled, true)
       import f._
       logger.debug(s"msg ${1}")
@@ -343,8 +352,10 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.trace(msg)
       verify(underlying, never).trace(anyString)
     }
+  }
+  "Calling trace with an interpolated message" should {
 
-    "call the underlying logger's trace method if the trace level is enabled and string is interpolated" in {
+    "call the underlying logger's trace method if the trace level is enabled" in {
       val f = fixture(_.isTraceEnabled, true)
       import f._
       logger.trace(s"msg $arg1 $arg2 $arg3")

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -74,6 +74,19 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(s"foo {} bar $arg1")
       verify(underlying).error("foo \\{} bar {}", arg1)
     }
+
+    "call the underlying logger's error method when the interpolated string contains escape sequences" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo\nbar $arg1")
+      verify(underlying).error(s"foo\nbar {}", arg1)
+    }
+    "call the underlying logger's error method when the interpolated string is triple quoted and contains escape sequences" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"""foo\nbar $arg1""")
+      verify(underlying).error(s"""foo\nbar {}""", arg1)
+    }
   }
 
   "Calling error with a message and cause" should {

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -57,6 +57,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       logger.error(s"msg $arg1 $arg2")
       verify(underlying).error("msg {} {}", List(arg1, arg2): _*)
     }
+
+    "call the underlying logger's error method with the string representation of interpolated AnyVal arguments" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"msg ${1}")
+      verify(underlying).error("msg {}", 1.toString)
+    }
   }
 
   "Calling error with a message and cause" should {
@@ -260,6 +267,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.debug(s"msg $arg1 $arg2 $arg3")
       verify(underlying).debug("msg {} {} {}", arg1, arg2, arg3)
+    }
+
+    "call the underlying logger's debug method with the string representation of interpolated AnyVal arguments" in {
+      val f = fixture(_.isDebugEnabled, true)
+      import f._
+      logger.debug(s"msg ${1}")
+      verify(underlying).debug("msg {}", 1.toString)
     }
   }
 

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -61,37 +61,6 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying).error("msg {} {}", List(arg1, arg2): _*)
     }
 
-    "call the underlying logger's error method with the string representation AnyVal arguments" in {
-      val f = fixture(_.isErrorEnabled, true)
-      import f._
-      logger.error(s"msg ${1}")
-      verify(underlying).error("msg {}", 1.toString)
-    }
-
-    "call the underlying logger's error method escaping literal format anchors" in {
-      val f = fixture(_.isErrorEnabled, true)
-      import f._
-      logger.error(s"foo {} bar $arg1")
-      verify(underlying).error("foo \\{} bar {}", arg1)
-    }
-    "call the underlying logger's error method without escaping format anchors when the message has no interpolations" in {
-      val f = fixture(_.isErrorEnabled, true)
-      import f._
-      logger.error(s"foo {} bar")
-      verify(underlying).error("foo {} bar")
-    }
-    "call the underlying logger's error method when the interpolated string contains escape sequences" in {
-      val f = fixture(_.isErrorEnabled, true)
-      import f._
-      logger.error(s"foo\nbar $arg1")
-      verify(underlying).error(s"foo\nbar {}", arg1)
-    }
-    "call the underlying logger's error method when the interpolated string is triple quoted and contains escape sequences" in {
-      val f = fixture(_.isErrorEnabled, true)
-      import f._
-      logger.error(s"""foo\nbar $arg1""")
-      verify(underlying).error(s"""foo\nbar {}""", arg1)
-    }
   }
 
   "Calling error with a message and cause" should {
@@ -154,6 +123,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).warn(anyString)
     }
   }
+
   "Calling warn with an interpolated message" should {
 
     "call the underlying logger's warn method if the warn level is enabled" in {
@@ -161,6 +131,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.warn(s"msg $arg1 $arg2 $arg3")
       verify(underlying).warn("msg {} {} {}", arg1, arg2, arg3)
+    }
+
+    "call the underlying logger's warn method with two arguments if the warn level is enabled" in {
+      val f = fixture(_.isWarnEnabled, true)
+      import f._
+      logger.warn(s"msg $arg1 $arg2")
+      verify(underlying).warn("msg {} {}", List(arg1, arg2): _*)
     }
   }
 
@@ -224,6 +201,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).info(anyString)
     }
   }
+
   "Calling info with an interpolated message" should {
 
     "call the underlying logger's info method if the info level is enabled" in {
@@ -231,6 +209,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.info(s"msg $arg1 $arg2 $arg3")
       verify(underlying).info("msg {} {} {}", arg1, arg2, arg3)
+    }
+
+    "call the underlying logger's info method with two arguments if the info level is enabled" in {
+      val f = fixture(_.isInfoEnabled, true)
+      import f._
+      logger.info(s"msg $arg1 $arg2")
+      verify(underlying).info("msg {} {}", List(arg1, arg2): _*)
     }
   }
 
@@ -303,11 +288,11 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying).debug("msg {} {} {}", arg1, arg2, arg3)
     }
 
-    "call the underlying logger's debug method with the string representation of AnyVal arguments" in {
+    "call the underlying logger's debug method with two arguments if the debug level is enabled" in {
       val f = fixture(_.isDebugEnabled, true)
       import f._
-      logger.debug(s"msg ${1}")
-      verify(underlying).debug("msg {}", 1.toString)
+      logger.debug(s"msg $arg1 $arg2")
+      verify(underlying).debug("msg {} {}", List(arg1, arg2): _*)
     }
   }
 
@@ -371,6 +356,7 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).trace(anyString)
     }
   }
+
   "Calling trace with an interpolated message" should {
 
     "call the underlying logger's trace method if the trace level is enabled" in {
@@ -378,6 +364,13 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       import f._
       logger.trace(s"msg $arg1 $arg2 $arg3")
       verify(underlying).trace("msg {} {} {}", arg1, arg2, arg3)
+    }
+
+    "call the underlying logger's trace method with two arguments if the trace level is enabled" in {
+      val f = fixture(_.isTraceEnabled, true)
+      import f._
+      logger.trace(s"msg $arg1 $arg2")
+      verify(underlying).trace("msg {} {}", List(arg1, arg2): _*)
     }
   }
 
@@ -420,6 +413,46 @@ class LoggerSpec extends WordSpec with Matchers with MockitoSugar {
       verify(underlying, never).trace(msg, List(arg1, arg2): _*)
       logger.trace(msg, arg1, arg2, arg3)
       verify(underlying, never).trace(msg, arg1, arg2, arg3)
+    }
+  }
+
+  // Interpolator destructuring corner cases
+
+  "Logging a message using the standard string interpolator" should {
+
+    "call the underlying format method with the string representation of AnyVal arguments" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"msg ${1}")
+      verify(underlying).error("msg {}", 1.toString)
+    }
+
+    "call the underlying format method escaping literal format anchors" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo {} bar $arg1")
+      verify(underlying).error("foo \\{} bar {}", arg1)
+    }
+
+    "call the underlying method without escaping format anchors when the message has no interpolations" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo {} bar")
+      verify(underlying).error("foo {} bar")
+    }
+
+    "call the underlying format method when the interpolated string contains escape sequences" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"foo\nbar $arg1")
+      verify(underlying).error(s"foo\nbar {}", arg1)
+    }
+
+    "call the underlying format method when the interpolated string is triple quoted and contains escape sequences" in {
+      val f = fixture(_.isErrorEnabled, true)
+      import f._
+      logger.error(s"""foo\nbar $arg1""")
+      verify(underlying).error(s"""foo\nbar {}""", arg1)
     }
   }
 


### PR DESCRIPTION
The interpolation destructuring added in 3.6.0 attempts to convert interpolated messages to slf4j message formatting calls. These have signature `(String, Object*)Unit`, and as such any interpolations involving value types result in compilation errors. The simplest fix I came up with for this is to invoke `toString` on such interpolations, as they cannot be null.

The implementation also doesn't escape `{}` appearing in string parts, and doesn't account for Scala's wonky escape handling for interpolators.