### PR TITLE
Update to scala 2.11.12

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Version {
   val logback   = "1.2.3"
   val mockito   = "1.10.19"
-  val scala     = "2.11.11"
+  val scala     = "2.11.12"
   val crossScala = List(scala, "2.12.4", "2.13.0-M2")
   val scalaTest = "3.0.4"
   val slf4j     = "1.7.25"


### PR DESCRIPTION
Some dependency and security checkers complain about scala 2.11.11 and scala 2.12.<4 artifacts due to the compiler security issue. Would be nice if we could get a scala-logging 3.7.3 release out soon.