### PR TITLE
travis-ci no longer support oraclejdk7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ scala:
 env:
 - JDK=oraclejdk8
 - JDK=openjdk8
-- JDK=oraclejdk7
 - JDK=openjdk7
 addons:
   # https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
@@ -21,10 +20,6 @@ matrix:
   # scala 2.12 and 2.13 require java 8
   exclude:
     - scala: 2.12.4
-      env: JDK=oraclejdk7
-    - scala: 2.12.4
       env: JDK=openjdk7
-    - scala: 2.13.0-M2
-      env: JDK=oraclejdk7
     - scala: 2.13.0-M2
       env: JDK=openjdk7


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879

> My guess is that we can no longer support oraclejdk7 on our recent build images due to Oracle's withdrawal. http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html

https://travis-ci.org/typesafehub/scala-logging/jobs/319727211

```
$ export JDK=oraclejdk7
Disabling Gradle daemon
0.00s$ mkdir -p ~/.gradle && echo "org.gradle.daemon=false" >> ~/.gradle/gradle.properties
$ export PATH=$JAVA_HOME/bin:$PATH
$ export JVM_OPTS=@/etc/sbt/jvmopts
$ export SBT_OPTS=@/etc/sbt/sbtopts
$ java -Xmx32m -version
java version "1.8.0_151"
Java(TM) SE Runtime Environment (build 1.8.0_151-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.151-b12, mixed mode)
$ javac -J-Xmx32m -version
javac 1.8.0_151
```